### PR TITLE
fix: add annotation to return type

### DIFF
--- a/litestar_htmx/plugin.py
+++ b/litestar_htmx/plugin.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class HTMXPlugin(InitPluginProtocol):
     """Flash messages Plugin."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the plugin."""
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 name = "litestar-htmx"
 readme = "README.md"
 requires-python = ">=3.8, <4.0"
-version = "0.2.2"
+version = "0.2.3"
 
 [build-system]
 build-backend = "hatchling.build"
@@ -69,34 +69,34 @@ ignore-words-list = "te"
 skip = 'uv.lock'
 
 [tool.coverage.run]
-omit = ["*/tests/*"]
-plugins = ["covdefaults"]
-source = ["litestar_htmx"]
 branch = true
 concurrency = ["multiprocessing"]
 disable_warnings = ["no-data-collected", "module-not-measured", "module-not-imported"]
+omit = ["*/tests/*"]
 parallel = true
+plugins = ["covdefaults"]
+source = ["litestar_htmx"]
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
 exclude_lines = [
-  # Have to re-enable the standard pragma
-  "pragma: no cover",
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
 
-  # Don't complain about missing debug-only code:
-  "def __repr__",
-  "if self\\.debug",
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "if self\\.debug",
 
-  # Don't complain if tests don't hit defensive assertion code:
-  "raise AssertionError",
-  "raise NotImplementedError",
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
 
-  # Don't complain if non-runnable code isn't run:
-  "if 0:",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-  'class .*\bProtocol\):',
-  '@(abc\.)?abstractmethod',
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    'class .*\bProtocol\):',
+    '@(abc\.)?abstractmethod',
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ mako = [
 
 [[package]]
 name = "litestar-htmx"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "litestar" },


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

## Summary by Sourcery

Bug Fixes:
- Add missing return type annotation to the __init__ method of the HTMXPlugin class.