### PR TITLE
feat: adds `HTMXConfig` for plugin customization

### DIFF
--- a/litestar_htmx/__init__.py
+++ b/litestar_htmx/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from litestar_htmx.plugin import HTMXPlugin
+from litestar_htmx.plugin import HTMXConfig, HTMXPlugin
 from litestar_htmx.request import HTMXDetails, HTMXHeaders, HTMXRequest
 from litestar_htmx.response import (
     ClientRedirect,
@@ -25,6 +25,7 @@ from litestar_htmx.types import (
 
 __all__ = (
     "HTMXPlugin",
+    "HTMXConfig",
     "HTMXDetails",
     "HTMXHeaders",
     "HTMXRequest",

--- a/litestar_htmx/plugin.py
+++ b/litestar_htmx/plugin.py
@@ -45,7 +45,7 @@ class HTMXPlugin(InitPluginProtocol):
         self._config = config or HTMXConfig()
 
     @property
-    def config(self):
+    def config(self) -> HTMXConfig:
         return self._config
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:

--- a/litestar_htmx/plugin.py
+++ b/litestar_htmx/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from litestar.plugins import InitPluginProtocol
@@ -24,11 +25,28 @@ if TYPE_CHECKING:
     from litestar.config.app import AppConfig
 
 
+@dataclass
+class HTMXConfig:
+    """Configuration for HTMX Plugin."""
+
+    set_request_class_globally: bool = True
+    """Sets the `app_config.request_class` to the `HTMXRequest` class at the application level.  Defaults to True"""
+
+
 class HTMXPlugin(InitPluginProtocol):
     """HTMX Plugin."""
 
-    def __init__(self) -> None:
-        """Initialize the plugin."""
+    def __init__(self, config: HTMXConfig | None = None) -> None:
+        """Initialize the plugin.
+
+        Args:
+            config: Configuration for flash messages, including the template engine instance.
+        """
+        self._config = config or HTMXConfig()
+
+    @property
+    def config(self):
+        return self._config
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         """Register the HTMX configuration.
@@ -39,7 +57,7 @@ class HTMXPlugin(InitPluginProtocol):
         Returns:
             The application configuration with the message callable registered.
         """
-        if app_config.request_class is None:
+        if self.config.set_request_class_globally and app_config.request_class is None:
             app_config.request_class = HTMXRequest
         app_config.signature_types = [
             HTMXRequest,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 name = "litestar-htmx"
 readme = "README.md"
 requires-python = ">=3.8, <4.0"
-version = "0.2.4"
+version = "0.3.0"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/tests/test_htmx_plugin.py
+++ b/tests/test_htmx_plugin.py
@@ -1,0 +1,30 @@
+import pytest
+from litestar.config.app import AppConfig
+
+from litestar_htmx import HTMXConfig, HTMXPlugin, HTMXRequest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize(
+    "set_request_class_globally",
+    (True, False),
+)
+def test_request_class(set_request_class_globally: bool) -> None:
+    config = HTMXConfig(set_request_class_globally=set_request_class_globally)
+    plugin = HTMXPlugin(config=config)
+    app_config = plugin.on_app_init(AppConfig())
+    if set_request_class_globally:
+        assert app_config.request_class == HTMXRequest
+    else:
+        assert app_config.request_class is None
+
+
+class CustomHTMXRequest(HTMXRequest):
+    """Extra functionality."""
+
+
+def test_request_class_no_override() -> None:
+    plugin = HTMXPlugin()
+    app_config = plugin.on_app_init(AppConfig(request_class=CustomHTMXRequest))
+    assert app_config.request_class == CustomHTMXRequest

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ mako = [
 
 [[package]]
 name = "litestar-htmx"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "litestar" },


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

## Summary by Sourcery

Add `HTMXConfig` class to enable customization of the HTMX plugin, allowing users to configure whether the `HTMXRequest` class is set globally. Update `HTMXPlugin` to utilize this configuration and add corresponding tests to ensure correct behavior.

New Features:
- Introduce `HTMXConfig` class to allow customization of the HTMX plugin.

Enhancements:
- Modify `HTMXPlugin` to accept an optional `HTMXConfig` parameter for configuration.

Tests:
- Add tests for `HTMXPlugin` to verify behavior of `set_request_class_globally` configuration.