### PR TITLE
feat: Make HTMXRequest generic

### DIFF
--- a/litestar_htmx/request.py
+++ b/litestar_htmx/request.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from contextlib import suppress
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from litestar import Request
-from litestar.connection.base import empty_receive, empty_send
+from litestar.connection.base import AuthT, StateT, UserT, empty_receive, empty_send
 from litestar.exceptions import SerializationException
 from litestar.serialization import decode_json
 
@@ -103,7 +103,7 @@ class HTMXDetails:
         return None
 
 
-class HTMXRequest(Request):
+class HTMXRequest(Generic[UserT, AuthT, StateT], Request[UserT, AuthT, StateT]):
     """HTMX Request class to work with HTMX client."""
 
     __slots__ = ("htmx",)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Add type parameters to `HTMXRequest` that mirror those of `litestar.Request`, allowing type-safe (ish) access to the `user`, `auth`, and `state `attributes of `HTMXRequest`.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes #13.

## Summary by Sourcery

Enhancements:
- Add Generic[UserT, AuthT, StateT] parameters to HTMXRequest to allow type-safe access to user, auth, and state attributes